### PR TITLE
test: enable multiarch build in PR for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -47,7 +46,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -59,19 +58,23 @@ jobs:
       - name: Build and push multi-arch images
         if: github.event_name != 'pull_request'
         env:
-          KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync
         run: |
-          # Convert tags to comma-separated list for ko
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',' | sed 's/,$//')
-          echo "Building for tags: $TAGS"
+          # Build and push with ko - it will automatically tag based on git ref
+          IMAGE_REF=$(ko build --bare --platform=linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x ./cmd/cert-manager-sync)
+          echo "Built image: $IMAGE_REF"
           
-          # Build and push multi-arch images with ko (all major architectures)
-          ko build --bare --platform=linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x --tags="$TAGS" ./cmd/cert-manager-sync
+          # If this is main/master branch, also tag as latest
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "Creating latest tag..."
+            REPO_BASE="${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync"
+            docker buildx imagetools create --tag "${REPO_BASE}:latest" "$IMAGE_REF"
+          fi
 
       - name: Build image for PR (dry-run)
         if: github.event_name == 'pull_request'
         env:
           KO_DOCKER_REPO: ko.local
         run: |
-          # For PRs, build locally without pushing (amd64 only for speed)
-          ko build --platform=linux/amd64 --local ./cmd/cert-manager-sync
+          # For PRs, test multiarch build locally without pushing
+          ko build --platform=linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x --local ./cmd/cert-manager-sync

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync
         run: |
           # Build and push with ko - it will automatically tag based on git ref
-          IMAGE_REF=$(ko build --bare --platform=linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x ./cmd/cert-manager-sync)
+          IMAGE_REF=$(ko build --bare --platform=all ./cmd/cert-manager-sync)
           echo "Built image: $IMAGE_REF"
           
           # If this is main/master branch, also tag as latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push multi-arch images
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push multi-arch images
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         env:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-manager-sync
         run: |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Annotations:
     cert-manager-sync.lestak.sh/cloudflare-secret-name: "example-cloudflare-secret" # secret in same namespace which contains the cloudflare api token. If provided in format "namespace/secret-name", will look in that namespace for the secret
     cert-manager-sync.lestak.sh/cloudflare-zone-id: "example-zone-id" # cloudflare zone id
     cert-manager-sync.lestak.sh/cloudflare-cert-id: "" # will be auto-filled by operator for in-place renewals
+    cert-manager-sync.lestak.sh/cloudflare-cert-type: "sni_custom" # optional: certificate type (sni_custom or legacy_custom), defaults to sni_custom for free plan compatibility. Note: type can only be set when creating new certificates
 ```
 
 ### DigitalOcean

--- a/stores/cloudflare/cloudflare.go
+++ b/stores/cloudflare/cloudflare.go
@@ -61,7 +61,6 @@ func (s *CloudflareStore) FromConfig(c tlssecret.GenericSecretSyncConfig) error 
 }
 
 func (s *CloudflareStore) Sync(c *tlssecret.Certificate) (map[string]string, error) {
-	s.SecretNamespace = c.Namespace
 	l := log.WithFields(log.Fields{
 		"action":          "Sync",
 		"store":           "cloudflare",
@@ -72,6 +71,12 @@ func (s *CloudflareStore) Sync(c *tlssecret.Certificate) (map[string]string, err
 	if s.SecretName == "" {
 		return nil, fmt.Errorf("secret name not found in certificate annotations")
 	}
+	
+	// If no explicit secret namespace was provided, use the certificate's namespace
+	if s.SecretNamespace == "" {
+		s.SecretNamespace = c.Namespace
+	}
+	
 	ctx := context.Background()
 	if err := s.GetApiToken(ctx); err != nil {
 		l.WithError(err).Errorf("GetApiToken error")


### PR DESCRIPTION
- Temporarily enable all architectures in PR builds to test ko functionality
- This will help verify that the ko configuration works correctly
- Can be reverted back to amd64-only after testing